### PR TITLE
chore: bump c-kzg to v2.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -238,14 +238,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc1360603efdfba91151e623f13a4f4d3dc4af4adc1cbd90bf37c81e84db4c77"
 dependencies = [
  "alloy-rlp",
- "arbitrary",
  "bytes",
  "cfg-if",
  "const-hex",
- "derive_arbitrary",
  "derive_more 1.0.0",
  "foldhash",
- "getrandom 0.2.15",
  "hashbrown 0.15.2",
  "indexmap 2.7.1",
  "itoa",
@@ -253,7 +250,6 @@ dependencies = [
  "keccak-asm",
  "paste",
  "proptest",
- "proptest-derive",
  "rand 0.8.5",
  "ruint",
  "rustc-hash 2.1.0",
@@ -269,11 +265,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70b98b99c1dcfbe74d7f0b31433ff215e7d1555e367d90e62db904f3c9d4ff53"
 dependencies = [
  "alloy-rlp",
+ "arbitrary",
  "bytes",
  "cfg-if",
  "const-hex",
+ "derive_arbitrary",
  "derive_more 2.0.1",
  "foldhash",
+ "getrandom 0.3.1",
  "hashbrown 0.15.2",
  "indexmap 2.7.1",
  "itoa",
@@ -281,6 +280,7 @@ dependencies = [
  "keccak-asm",
  "paste",
  "proptest",
+ "proptest-derive",
  "rand 0.9.0",
  "ruint",
  "rustc-hash 2.1.0",
@@ -884,7 +884,7 @@ checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 name = "beacon_chain"
 version = "0.2.0"
 dependencies = [
- "alloy-primitives 0.8.20",
+ "alloy-primitives 1.0.0",
  "bitvec 1.0.1",
  "bls",
  "criterion",
@@ -893,7 +893,7 @@ dependencies = [
  "eth2",
  "eth2_network_config",
  "ethereum_hashing",
- "ethereum_serde_utils",
+ "ethereum_serde_utils 0.7.0",
  "ethereum_ssz",
  "ethereum_ssz_derive",
  "execution_layer",
@@ -1136,11 +1136,11 @@ checksum = "8d696c370c750c948ada61c69a0ee2cbbb9c50b1019ddb86d9317157a99c2cae"
 name = "bls"
 version = "0.2.0"
 dependencies = [
- "alloy-primitives 0.8.20",
+ "alloy-primitives 1.0.0",
  "arbitrary",
  "blst",
  "ethereum_hashing",
- "ethereum_serde_utils",
+ "ethereum_serde_utils 0.7.0",
  "ethereum_ssz",
  "fixed_bytes",
  "hex",
@@ -1514,7 +1514,7 @@ checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
 name = "clap_utils"
 version = "0.1.0"
 dependencies = [
- "alloy-primitives 0.8.20",
+ "alloy-primitives 1.0.0",
  "clap",
  "dirs",
  "eth2_network_config",
@@ -2493,10 +2493,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "educe"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d7bc049e1bd8cdeb31b68bbd586a9464ecf9f3944af3958a7a9d0f8b9799417"
+dependencies = [
+ "enum-ordinalize",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.98",
+]
+
+[[package]]
 name = "ef_tests"
 version = "0.2.0"
 dependencies = [
- "alloy-primitives 0.8.20",
+ "alloy-primitives 1.0.0",
  "beacon_chain",
  "bls",
  "compare_fields",
@@ -2604,6 +2616,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1e6a265c649f3f5979b601d26f1d05ada116434c87741c9493cb56218f76cbc"
 dependencies = [
  "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.98",
+]
+
+[[package]]
+name = "enum-ordinalize"
+version = "4.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fea0dcfa4e54eeb516fe454635a95753ddd39acda650ce703031c6973e315dd5"
+dependencies = [
+ "enum-ordinalize-derive",
+]
+
+[[package]]
+name = "enum-ordinalize-derive"
+version = "4.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d28318a75d4aead5c4db25382e8ef717932d0346600cacae6357eb5941bc5ff"
+dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.98",
@@ -2728,7 +2760,7 @@ dependencies = [
  "derivative",
  "either",
  "eth2_keystore",
- "ethereum_serde_utils",
+ "ethereum_serde_utils 0.7.0",
  "ethereum_ssz",
  "ethereum_ssz_derive",
  "futures",
@@ -2970,21 +3002,39 @@ dependencies = [
 ]
 
 [[package]]
-name = "ethereum_ssz"
-version = "0.7.1"
+name = "ethereum_serde_utils"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e999563461faea0ab9bc0024e5e66adcee35881f3d5062f52f31a4070fe1522"
+checksum = "3dc1355dbb41fbbd34ec28d4fb2a57d9a70c67ac3c19f6a5ca4d4a176b9e997a"
 dependencies = [
- "alloy-primitives 0.8.20",
+ "alloy-primitives 1.0.0",
+ "hex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+]
+
+[[package]]
+name = "ethereum_ssz"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ca8ba45b63c389c6e115b095ca16381534fdcc03cf58176a3f8554db2dbe19b"
+dependencies = [
+ "alloy-primitives 1.0.0",
+ "arbitrary",
+ "ethereum_serde_utils 0.8.0",
  "itertools 0.13.0",
+ "serde",
+ "serde_derive",
  "smallvec",
+ "typenum",
 ]
 
 [[package]]
 name = "ethereum_ssz_derive"
-version = "0.7.1"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3deae99c8e74829a00ba7a92d49055732b3c1f093f2ccfa3cbc621679b6fa91"
+checksum = "0dd55d08012b4e0dfcc92b8d6081234df65f2986ad34cc76eeed69c5e2ce7506"
 dependencies = [
  "darling 0.20.10",
  "proc-macro2",
@@ -3181,14 +3231,14 @@ name = "execution_layer"
 version = "0.1.0"
 dependencies = [
  "alloy-consensus",
- "alloy-primitives 0.8.20",
+ "alloy-primitives 1.0.0",
  "alloy-rlp",
  "arc-swap",
  "builder_client",
  "bytes",
  "eth2",
  "eth2_network_config",
- "ethereum_serde_utils",
+ "ethereum_serde_utils 0.7.0",
  "ethereum_ssz",
  "ethers-core",
  "fixed_bytes",
@@ -3368,7 +3418,7 @@ dependencies = [
 name = "fixed_bytes"
 version = "0.1.0"
 dependencies = [
- "alloy-primitives 0.8.20",
+ "alloy-primitives 1.0.0",
  "safe_arith",
 ]
 
@@ -4171,7 +4221,7 @@ dependencies = [
  "either",
  "eth1",
  "eth2",
- "ethereum_serde_utils",
+ "ethereum_serde_utils 0.7.0",
  "ethereum_ssz",
  "execution_layer",
  "futures",
@@ -4909,7 +4959,7 @@ dependencies = [
  "criterion",
  "derivative",
  "ethereum_hashing",
- "ethereum_serde_utils",
+ "ethereum_serde_utils 0.7.0",
  "ethereum_ssz",
  "ethereum_ssz_derive",
  "hex",
@@ -5538,7 +5588,7 @@ dependencies = [
 name = "lighthouse_network"
 version = "0.2.0"
 dependencies = [
- "alloy-primitives 0.8.20",
+ "alloy-primitives 1.0.0",
  "alloy-rlp",
  "async-channel",
  "bytes",
@@ -5824,7 +5874,7 @@ dependencies = [
 name = "merkle_proof"
 version = "0.2.0"
 dependencies = [
- "alloy-primitives 0.8.20",
+ "alloy-primitives 1.0.0",
  "ethereum_hashing",
  "fixed_bytes",
  "quickcheck",
@@ -5885,13 +5935,13 @@ dependencies = [
 
 [[package]]
 name = "milhouse"
-version = "0.3.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f68e33f98199224d1073f7c1468ea6abfea30736306fb79c7181a881e97ea32f"
+checksum = "bdc758ed0c2597254f45baa97c8aa35f44ae0c8b04ddc355f135ced531f316d6"
 dependencies = [
- "alloy-primitives 0.8.20",
+ "alloy-primitives 1.0.0",
  "arbitrary",
- "derivative",
+ "educe",
  "ethereum_hashing",
  "ethereum_ssz",
  "ethereum_ssz_derive",
@@ -6186,7 +6236,7 @@ dependencies = [
 name = "network"
 version = "0.2.0"
 dependencies = [
- "alloy-primitives 0.8.20",
+ "alloy-primitives 1.0.0",
  "alloy-rlp",
  "anyhow",
  "async-channel",
@@ -8397,7 +8447,7 @@ name = "signing_method"
 version = "0.1.0"
 dependencies = [
  "eth2_keystore",
- "ethereum_serde_utils",
+ "ethereum_serde_utils 0.7.0",
  "lockfile",
  "parking_lot 0.12.3",
  "reqwest",
@@ -8515,7 +8565,7 @@ name = "slashing_protection"
 version = "0.1.0"
 dependencies = [
  "arbitrary",
- "ethereum_serde_utils",
+ "ethereum_serde_utils 0.7.0",
  "filesystem",
  "r2d2",
  "r2d2_sqlite",
@@ -8708,13 +8758,12 @@ dependencies = [
 
 [[package]]
 name = "ssz_types"
-version = "0.8.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35e0719d2b86ac738a55ae71a8429f52aa2741da988f1fd0975b4cc610fd1e08"
+checksum = "75b55bedc9a18ed2860a46d6beb4f4082416ee1d60be0cc364cebdcdddc7afd4"
 dependencies = [
  "arbitrary",
- "derivative",
- "ethereum_serde_utils",
+ "ethereum_serde_utils 0.8.0",
  "ethereum_ssz",
  "itertools 0.13.0",
  "serde",
@@ -8877,7 +8926,7 @@ dependencies = [
 name = "swap_or_not_shuffle"
 version = "0.2.0"
 dependencies = [
- "alloy-primitives 0.8.20",
+ "alloy-primitives 1.0.0",
  "criterion",
  "ethereum_hashing",
  "fixed_bytes",
@@ -9623,20 +9672,22 @@ dependencies = [
 
 [[package]]
 name = "tree_hash"
-version = "0.8.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "373495c23db675a5192de8b610395e1bec324d596f9e6111192ce903dc11403a"
+checksum = "ee44f4cef85f88b4dea21c0b1f58320bdf35715cf56d840969487cff00613321"
 dependencies = [
- "alloy-primitives 0.8.20",
+ "alloy-primitives 1.0.0",
  "ethereum_hashing",
+ "ethereum_ssz",
  "smallvec",
+ "typenum",
 ]
 
 [[package]]
 name = "tree_hash_derive"
-version = "0.8.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0857056ca4eb5de8c417309be42bcff6017b47e86fbaddde609b4633f66061e"
+checksum = "0bee2ea1551f90040ab0e34b6fb7f2fa3bad8acc925837ac654f2c78a13e3089"
 dependencies = [
  "darling 0.20.10",
  "proc-macro2",
@@ -9680,7 +9731,7 @@ checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
 name = "types"
 version = "0.2.1"
 dependencies = [
- "alloy-primitives 0.8.20",
+ "alloy-primitives 1.0.0",
  "alloy-rlp",
  "arbitrary",
  "beacon_chain",
@@ -9691,7 +9742,7 @@ dependencies = [
  "derivative",
  "eth2_interop_keypairs",
  "ethereum_hashing",
- "ethereum_serde_utils",
+ "ethereum_serde_utils 0.7.0",
  "ethereum_ssz",
  "ethereum_ssz_derive",
  "fixed_bytes",
@@ -9970,7 +10021,7 @@ dependencies = [
  "doppelganger_service",
  "eth2",
  "eth2_keystore",
- "ethereum_serde_utils",
+ "ethereum_serde_utils 0.7.0",
  "filesystem",
  "futures",
  "graffiti_file",
@@ -10035,7 +10086,7 @@ dependencies = [
  "eth2",
  "eth2_network_config",
  "eth2_wallet",
- "ethereum_serde_utils",
+ "ethereum_serde_utils 0.7.0",
  "hex",
  "regex",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -155,49 +155,78 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "alloy-consensus"
-version = "0.3.6"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "629b62e38d471cc15fea534eb7283d2f8a4e8bdb1811bcc5d66dda6cfce6fae1"
+checksum = "c2179ba839ac532f50279f5da2a6c5047f791f03f6f808b4dfab11327b97902f"
 dependencies = [
  "alloy-eips",
- "alloy-primitives",
+ "alloy-primitives 1.0.0",
  "alloy-rlp",
+ "alloy-serde",
+ "alloy-trie",
+ "auto_impl",
  "c-kzg",
+ "derive_more 2.0.1",
+ "either",
+ "k256 0.13.4",
+ "once_cell",
+ "serde",
+ "serde_with 3.12.0",
+ "thiserror 2.0.11",
+]
+
+[[package]]
+name = "alloy-eip2124"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "741bdd7499908b3aa0b159bba11e71c8cddd009a2c2eb7a06e825f1ec87900a5"
+dependencies = [
+ "alloy-primitives 1.0.0",
+ "alloy-rlp",
+ "crc",
+ "serde",
+ "thiserror 2.0.11",
 ]
 
 [[package]]
 name = "alloy-eip2930"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0069cf0642457f87a01a014f6dc29d5d893cd4fd8fddf0c3cdfad1bb3ebafc41"
+checksum = "dbe3e16484669964c26ac48390245d84c410b1a5f968976076c17184725ef235"
 dependencies = [
- "alloy-primitives",
+ "alloy-primitives 1.0.0",
  "alloy-rlp",
+ "serde",
 ]
 
 [[package]]
 name = "alloy-eip7702"
-version = "0.1.1"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea59dc42102bc9a1905dc57901edc6dd48b9f38115df86c7d252acba70d71d04"
+checksum = "804cefe429015b4244966c006d25bda5545fa9db5990e9c9079faf255052f50a"
 dependencies = [
- "alloy-primitives",
+ "alloy-primitives 1.0.0",
  "alloy-rlp",
+ "serde",
+ "thiserror 2.0.11",
 ]
 
 [[package]]
 name = "alloy-eips"
-version = "0.3.6"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f923dd5fca5f67a43d81ed3ebad0880bd41f6dd0ada930030353ac356c54cd0f"
+checksum = "609515c1955b33af3d78d26357540f68c5551a90ef58fd53def04f2aa074ec43"
 dependencies = [
+ "alloy-eip2124",
  "alloy-eip2930",
  "alloy-eip7702",
- "alloy-primitives",
+ "alloy-primitives 1.0.0",
  "alloy-rlp",
+ "alloy-serde",
+ "auto_impl",
  "c-kzg",
- "derive_more 1.0.0",
- "once_cell",
+ "derive_more 2.0.1",
+ "either",
  "serde",
  "sha2 0.10.8",
 ]
@@ -234,6 +263,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloy-primitives"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70b98b99c1dcfbe74d7f0b31433ff215e7d1555e367d90e62db904f3c9d4ff53"
+dependencies = [
+ "alloy-rlp",
+ "bytes",
+ "cfg-if",
+ "const-hex",
+ "derive_more 2.0.1",
+ "foldhash",
+ "hashbrown 0.15.2",
+ "indexmap 2.7.1",
+ "itoa",
+ "k256 0.13.4",
+ "keccak-asm",
+ "paste",
+ "proptest",
+ "rand 0.9.0",
+ "ruint",
+ "rustc-hash 2.1.0",
+ "serde",
+ "sha3 0.10.8",
+ "tiny-keccak",
+]
+
+[[package]]
 name = "alloy-rlp"
 version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -253,6 +309,33 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.98",
+]
+
+[[package]]
+name = "alloy-serde"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4dba6ff08916bc0a9cbba121ce21f67c0b554c39cf174bc7b9df6c651bd3c3b"
+dependencies = [
+ "alloy-primitives 1.0.0",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "alloy-trie"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "983d99aa81f586cef9dae38443245e585840fcf0fc58b09aee0b1f27aed1d500"
+dependencies = [
+ "alloy-primitives 1.0.0",
+ "alloy-rlp",
+ "arrayvec",
+ "derive_more 2.0.1",
+ "nybbles",
+ "serde",
+ "smallvec",
+ "tracing",
 ]
 
 [[package]]
@@ -801,7 +884,7 @@ checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 name = "beacon_chain"
 version = "0.2.0"
 dependencies = [
- "alloy-primitives",
+ "alloy-primitives 0.8.20",
  "bitvec 1.0.1",
  "bls",
  "criterion",
@@ -966,18 +1049,18 @@ dependencies = [
 
 [[package]]
 name = "bit-set"
-version = "0.5.3"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
 dependencies = [
  "bit-vec",
 ]
 
 [[package]]
 name = "bit-vec"
-version = "0.6.3"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bitflags"
@@ -1053,7 +1136,7 @@ checksum = "8d696c370c750c948ada61c69a0ee2cbbb9c50b1019ddb86d9317157a99c2cae"
 name = "bls"
 version = "0.2.0"
 dependencies = [
- "alloy-primitives",
+ "alloy-primitives 0.8.20",
  "arbitrary",
  "blst",
  "ethereum_hashing",
@@ -1070,9 +1153,9 @@ dependencies = [
 
 [[package]]
 name = "blst"
-version = "0.3.13"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4378725facc195f1a538864863f6de233b500a8862747e7f165078a419d5e874"
+checksum = "47c79a94619fade3c0b887670333513a67ac28a6a7e653eb260bf0d4103db38d"
 dependencies = [
  "cc",
  "glob",
@@ -1103,7 +1186,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed59b5c00048f48d7af971b71f800fdf23e858844a6f9e4d32ca72e9399e7864"
 dependencies = [
  "serde",
- "serde_with",
+ "serde_with 1.14.0",
 ]
 
 [[package]]
@@ -1207,10 +1290,11 @@ dependencies = [
 
 [[package]]
 name = "c-kzg"
-version = "1.0.3"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0307f72feab3300336fb803a57134159f6e20139af1357f36c54cb90d8e8928"
+checksum = "4e7e3c397401eb76228c89561cf22f85f41c95aa799ee9d860de3ea1cbc728fc"
 dependencies = [
+ "arbitrary",
  "blst",
  "cc",
  "glob",
@@ -1323,6 +1407,7 @@ dependencies = [
  "android-tzdata",
  "iana-time-zone",
  "num-traits",
+ "serde",
  "windows-targets 0.52.6",
 ]
 
@@ -1429,7 +1514,7 @@ checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
 name = "clap_utils"
 version = "0.1.0"
 dependencies = [
- "alloy-primitives",
+ "alloy-primitives 0.8.20",
  "clap",
  "dirs",
  "eth2_network_config",
@@ -1648,6 +1733,21 @@ dependencies = [
  "hex",
  "sha2 0.10.8",
 ]
+
+[[package]]
+name = "crc"
+version = "3.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69e6e4d7b33a94f0991c26729976b10ebde1d34c3ee82408fb536164fa10d636"
+dependencies = [
+ "crc-catalog",
+]
+
+[[package]]
+name = "crc-catalog"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
 
 [[package]]
 name = "crc32fast"
@@ -2056,6 +2156,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
 dependencies = [
  "powerfmt",
+ "serde",
 ]
 
 [[package]]
@@ -2099,7 +2200,16 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a9b99b9cbbe49445b21764dc0625032a89b145a2642e67603e1c936f5458d05"
 dependencies = [
- "derive_more-impl",
+ "derive_more-impl 1.0.0",
+]
+
+[[package]]
+name = "derive_more"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "093242cf7570c207c83073cf82f79706fe7b8317e98620a47d5be7c3d8497678"
+dependencies = [
+ "derive_more-impl 2.0.1",
 ]
 
 [[package]]
@@ -2107,6 +2217,18 @@ name = "derive_more-impl"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb7330aeadfbe296029522e6c40f315320aba36fc43a5b3632f3795348f3bd22"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.98",
+ "unicode-xid",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bda628edc44c4bb645fbe0f758797143e4e07926f7ebf4e9bdfbd3d2ce621df3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2374,7 +2496,7 @@ dependencies = [
 name = "ef_tests"
 version = "0.2.0"
 dependencies = [
- "alloy-primitives",
+ "alloy-primitives 0.8.20",
  "beacon_chain",
  "bls",
  "compare_fields",
@@ -2404,9 +2526,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.13.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "elliptic-curve"
@@ -2840,7 +2962,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70cbccfccf81d67bff0ab36e591fa536c8a935b078a7b0e58c1d00d418332fc9"
 dependencies = [
- "alloy-primitives",
+ "alloy-primitives 0.8.20",
  "hex",
  "serde",
  "serde_derive",
@@ -2853,7 +2975,7 @@ version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e999563461faea0ab9bc0024e5e66adcee35881f3d5062f52f31a4070fe1522"
 dependencies = [
- "alloy-primitives",
+ "alloy-primitives 0.8.20",
  "itertools 0.13.0",
  "smallvec",
 ]
@@ -3059,7 +3181,7 @@ name = "execution_layer"
 version = "0.1.0"
 dependencies = [
  "alloy-consensus",
- "alloy-primitives",
+ "alloy-primitives 0.8.20",
  "alloy-rlp",
  "arc-swap",
  "builder_client",
@@ -3246,7 +3368,7 @@ dependencies = [
 name = "fixed_bytes"
 version = "0.1.0"
 dependencies = [
- "alloy-primitives",
+ "alloy-primitives 0.8.20",
  "safe_arith",
 ]
 
@@ -4529,6 +4651,7 @@ checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
 dependencies = [
  "autocfg",
  "hashbrown 0.12.3",
+ "serde",
 ]
 
 [[package]]
@@ -4907,7 +5030,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
 dependencies = [
  "cfg-if",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -5415,7 +5538,7 @@ dependencies = [
 name = "lighthouse_network"
 version = "0.2.0"
 dependencies = [
- "alloy-primitives",
+ "alloy-primitives 0.8.20",
  "alloy-rlp",
  "async-channel",
  "bytes",
@@ -5701,7 +5824,7 @@ dependencies = [
 name = "merkle_proof"
 version = "0.2.0"
 dependencies = [
- "alloy-primitives",
+ "alloy-primitives 0.8.20",
  "ethereum_hashing",
  "fixed_bytes",
  "quickcheck",
@@ -5766,7 +5889,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f68e33f98199224d1073f7c1468ea6abfea30736306fb79c7181a881e97ea32f"
 dependencies = [
- "alloy-primitives",
+ "alloy-primitives 0.8.20",
  "arbitrary",
  "derivative",
  "ethereum_hashing",
@@ -6063,7 +6186,7 @@ dependencies = [
 name = "network"
 version = "0.2.0"
 dependencies = [
- "alloy-primitives",
+ "alloy-primitives 0.8.20",
  "alloy-rlp",
  "anyhow",
  "async-channel",
@@ -6269,6 +6392,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "nybbles"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8983bb634df7248924ee0c4c3a749609b5abcb082c28fffe3254b3eb3602b307"
+dependencies = [
+ "alloy-rlp",
+ "const-hex",
+ "proptest",
+ "serde",
+ "smallvec",
+]
+
+[[package]]
 name = "object"
 version = "0.36.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6288,9 +6424,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.20.2"
+version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
+checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
 name = "oneshot_broadcast"
@@ -6973,9 +7109,9 @@ dependencies = [
 
 [[package]]
 name = "proptest"
-version = "1.5.0"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4c2511913b88df1637da85cc8d96ec8e43a3f8bb8ccb71ee1ac240d6f3df58d"
+checksum = "14cae93065090804185d3b75f0bf93b8eeda30c7a9b4a33d3bdb3988d6229e50"
 dependencies = [
  "bit-set",
  "bit-vec",
@@ -7198,6 +7334,7 @@ checksum = "3779b94aeb87e8bd4e834cee3650289ee9e0d5677f976ecdb6d219e5f4f6cd94"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.0",
+ "serde",
  "zerocopy 0.8.14",
 ]
 
@@ -7237,6 +7374,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b08f3c9802962f7e1b25113931d94f43ed9725bebc59db9d0c3e9a23b67e15ff"
 dependencies = [
  "getrandom 0.3.1",
+ "serde",
  "zerocopy 0.8.14",
 ]
 
@@ -7537,9 +7675,9 @@ dependencies = [
 
 [[package]]
 name = "ruint"
-version = "1.12.4"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5ef8fb1dd8de3870cb8400d51b4c2023854bbafd5431a3ac7e7317243e22d2f"
+checksum = "78a46eb779843b2c4f21fac5773e25d6d5b7c8f0922876c91541790d2ca27eef"
 dependencies = [
  "alloy-rlp",
  "arbitrary",
@@ -7555,6 +7693,7 @@ dependencies = [
  "primitive-types 0.12.2",
  "proptest",
  "rand 0.8.5",
+ "rand 0.9.0",
  "rlp",
  "ruint-macro",
  "serde",
@@ -8084,7 +8223,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "678b5a069e50bf00ecd22d0cd8ddf7c236f68581b03db652061ed5eb13a312ff"
 dependencies = [
  "serde",
- "serde_with_macros",
+ "serde_with_macros 1.5.2",
+]
+
+[[package]]
+name = "serde_with"
+version = "3.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6b6f7f2fcb69f747921f79f3926bd1e203fce4fef62c268dd3abfb6d86029aa"
+dependencies = [
+ "base64 0.22.1",
+ "chrono",
+ "hex",
+ "indexmap 1.9.3",
+ "indexmap 2.7.1",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "serde_with_macros 3.12.0",
+ "time",
 ]
 
 [[package]]
@@ -8097,6 +8254,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "serde_with_macros"
+version = "3.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d00caa5193a3c8362ac2b73be6b9e768aa5a4b2f721d8f4b339600c3cb51f8e"
+dependencies = [
+ "darling 0.20.10",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -8708,7 +8877,7 @@ dependencies = [
 name = "swap_or_not_shuffle"
 version = "0.2.0"
 dependencies = [
- "alloy-primitives",
+ "alloy-primitives 0.8.20",
  "criterion",
  "ethereum_hashing",
  "fixed_bytes",
@@ -9458,7 +9627,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "373495c23db675a5192de8b610395e1bec324d596f9e6111192ce903dc11403a"
 dependencies = [
- "alloy-primitives",
+ "alloy-primitives 0.8.20",
  "ethereum_hashing",
  "smallvec",
 ]
@@ -9511,7 +9680,7 @@ checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
 name = "types"
 version = "0.2.1"
 dependencies = [
- "alloy-primitives",
+ "alloy-primitives 0.8.20",
  "alloy-rlp",
  "arbitrary",
  "beacon_chain",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -113,7 +113,11 @@ resolver = "2"
 edition = "2021"
 
 [workspace.dependencies]
-alloy-primitives = { version = "0.8", features = ["rlp", "getrandom"] }
+alloy-primitives = { version = "1.0.0", features = [
+    "rlp",
+    "getrandom",
+    "serde",
+] }
 alloy-rlp = "0.3.4"
 alloy-consensus = "0.14.0"
 anyhow = "1"
@@ -139,8 +143,8 @@ discv5 = { version = "0.9", features = ["libp2p"] }
 env_logger = "0.9"
 ethereum_hashing = "0.7.0"
 ethereum_serde_utils = "0.7"
-ethereum_ssz = "0.7"
-ethereum_ssz_derive = "0.7"
+ethereum_ssz = "0.9"
+ethereum_ssz_derive = "0.9"
 ethers-core = "1"
 ethers-providers = { version = "1", default-features = false }
 exit-future = "0.2"
@@ -156,7 +160,7 @@ libsecp256k1 = "0.7"
 log = "0.4"
 lru = "0.12"
 maplit = "1"
-milhouse = "0.3"
+milhouse = "0.6"
 mockito = "1.5.0"
 num_cpus = "1"
 parking_lot = "0.12"
@@ -194,7 +198,7 @@ slog-term = "2"
 sloggers = { version = "2", features = ["json"] }
 smallvec = { version = "1.11.2", features = ["arbitrary"] }
 snap = "1"
-ssz_types = "0.8"
+ssz_types = "0.11.0"
 strum = { version = "0.24", features = ["derive"] }
 superstruct = "0.8"
 syn = "1"
@@ -213,8 +217,8 @@ tracing-appender = "0.2"
 tracing-core = "0.1"
 tracing-log = "0.2"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
-tree_hash = "0.8"
-tree_hash_derive = "0.8"
+tree_hash = "0.10.0"
+tree_hash_derive = "0.10.0"
 url = "2"
 uuid = { version = "0.8", features = ["serde", "v4"] }
 warp = { version = "0.3.7", default-features = false, features = ["tls"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -115,7 +115,7 @@ edition = "2021"
 [workspace.dependencies]
 alloy-primitives = { version = "0.8", features = ["rlp", "getrandom"] }
 alloy-rlp = "0.3.4"
-alloy-consensus = "0.3.0"
+alloy-consensus = "0.14.0"
 anyhow = "1"
 arbitrary = { version = "1", features = ["derive"] }
 async-channel = "1.9.0"
@@ -127,7 +127,7 @@ bytes = "1"
 clap = { version = "4.5.4", features = ["derive", "cargo", "wrap_help"] }
 # Turn off c-kzg's default features which include `blst/portable`. We can turn on blst's portable
 # feature ourselves when desired.
-c-kzg = { version = "1", default-features = false }
+c-kzg = { version = "2.1", default-features = false }
 compare_fields_derive = { path = "common/compare_fields_derive" }
 criterion = "0.5"
 delay_map = "0.4"

--- a/beacon_node/execution_layer/src/engine_api/json_structures.rs
+++ b/beacon_node/execution_layer/src/engine_api/json_structures.rs
@@ -77,7 +77,6 @@ pub struct JsonPayloadIdResponse {
 #[serde(bound = "E: EthSpec", rename_all = "camelCase", untagged)]
 pub struct JsonExecutionPayload<E: EthSpec> {
     pub parent_hash: ExecutionBlockHash,
-    #[serde(with = "serde_utils::address_hex")]
     pub fee_recipient: Address,
     pub state_root: Hash256,
     pub receipts_root: Hash256,
@@ -570,7 +569,6 @@ pub struct JsonWithdrawal {
     pub index: u64,
     #[serde(with = "serde_utils::u64_hex_be")]
     pub validator_index: u64,
-    #[serde(with = "serde_utils::address_hex")]
     pub address: Address,
     #[serde(with = "serde_utils::u64_hex_be")]
     pub amount: u64,
@@ -631,7 +629,6 @@ pub struct JsonPayloadAttributes {
     #[serde(with = "serde_utils::u64_hex_be")]
     pub timestamp: u64,
     pub prev_randao: Hash256,
-    #[serde(with = "serde_utils::address_hex")]
     pub suggested_fee_recipient: Address,
     #[superstruct(only(V2, V3))]
     pub withdrawals: Vec<JsonWithdrawal>,

--- a/common/eth2/src/lighthouse_vc/std_types.rs
+++ b/common/eth2/src/lighthouse_vc/std_types.rs
@@ -8,7 +8,6 @@ pub use slashing_protection::interchange::Interchange;
 #[derive(Debug, Deserialize, Serialize, PartialEq)]
 pub struct GetFeeRecipientResponse {
     pub pubkey: PublicKeyBytes,
-    #[serde(with = "serde_utils::address_hex")]
     pub ethaddress: Address,
 }
 

--- a/common/eth2/src/lighthouse_vc/types.rs
+++ b/common/eth2/src/lighthouse_vc/types.rs
@@ -162,7 +162,6 @@ pub struct Web3SignerValidatorRequest {
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
 pub struct UpdateFeeRecipientRequest {
-    #[serde(with = "serde_utils::address_hex")]
     pub ethaddress: Address,
 }
 

--- a/common/eth2/src/types.rs
+++ b/common/eth2/src/types.rs
@@ -565,7 +565,6 @@ pub struct BlockHeaderData {
 pub struct DepositContractData {
     #[serde(with = "serde_utils::quoted_u64")]
     pub chain_id: u64,
-    #[serde(with = "serde_utils::address_hex")]
     pub address: Address,
 }
 
@@ -1046,7 +1045,6 @@ pub struct SsePayloadAttributes {
     #[superstruct(getter(copy))]
     pub prev_randao: Hash256,
     #[superstruct(getter(copy))]
-    #[serde(with = "serde_utils::address_hex")]
     pub suggested_fee_recipient: Address,
     #[superstruct(only(V2, V3))]
     pub withdrawals: Vec<Withdrawal>,

--- a/consensus/state_processing/src/per_block_processing/errors.rs
+++ b/consensus/state_processing/src/per_block_processing/errors.rs
@@ -59,6 +59,7 @@ pub enum BlockProcessingError {
     BeaconStateError(BeaconStateError),
     SignatureSetError(SignatureSetError),
     SszTypesError(ssz_types::Error),
+    SszBitfieldError(ssz::BitfieldError),
     SszDecodeError(DecodeError),
     MerkleTreeError(MerkleTreeError),
     ArithError(ArithError),
@@ -110,6 +111,12 @@ impl From<ssz_types::Error> for BlockProcessingError {
     }
 }
 
+impl From<ssz::BitfieldError> for BlockProcessingError {
+    fn from(error: ssz::BitfieldError) -> Self {
+        BlockProcessingError::SszBitfieldError(error)
+    }
+}
+
 impl From<DecodeError> for BlockProcessingError {
     fn from(error: DecodeError) -> Self {
         BlockProcessingError::SszDecodeError(error)
@@ -153,6 +160,7 @@ impl From<BlockOperationError<HeaderInvalid>> for BlockProcessingError {
             BlockOperationError::BeaconStateError(e) => BlockProcessingError::BeaconStateError(e),
             BlockOperationError::SignatureSetError(e) => BlockProcessingError::SignatureSetError(e),
             BlockOperationError::SszTypesError(e) => BlockProcessingError::SszTypesError(e),
+            BlockOperationError::SszBitfieldError(e) => BlockProcessingError::SszBitfieldError(e),
             BlockOperationError::ConsensusContext(e) => BlockProcessingError::ConsensusContext(e),
             BlockOperationError::ArithError(e) => BlockProcessingError::ArithError(e),
         }
@@ -181,6 +189,7 @@ macro_rules! impl_into_block_processing_error_with_index {
                         BlockOperationError::BeaconStateError(e) => BlockProcessingError::BeaconStateError(e),
                         BlockOperationError::SignatureSetError(e) => BlockProcessingError::SignatureSetError(e),
                         BlockOperationError::SszTypesError(e) => BlockProcessingError::SszTypesError(e),
+                        BlockOperationError::SszBitfieldError(e) => BlockProcessingError::SszBitfieldError(e),
                         BlockOperationError::ConsensusContext(e) => BlockProcessingError::ConsensusContext(e),
                         BlockOperationError::ArithError(e) => BlockProcessingError::ArithError(e),
                     }
@@ -215,6 +224,7 @@ pub enum BlockOperationError<T> {
     BeaconStateError(BeaconStateError),
     SignatureSetError(SignatureSetError),
     SszTypesError(ssz_types::Error),
+    SszBitfieldError(ssz::BitfieldError),
     ConsensusContext(ContextError),
     ArithError(ArithError),
 }
@@ -239,6 +249,12 @@ impl<T> From<SignatureSetError> for BlockOperationError<T> {
 impl<T> From<ssz_types::Error> for BlockOperationError<T> {
     fn from(error: ssz_types::Error) -> Self {
         BlockOperationError::SszTypesError(error)
+    }
+}
+
+impl<T> From<ssz::BitfieldError> for BlockOperationError<T> {
+    fn from(error: ssz::BitfieldError) -> Self {
+        BlockOperationError::SszBitfieldError(error)
     }
 }
 
@@ -367,6 +383,7 @@ impl From<BlockOperationError<IndexedAttestationInvalid>>
             BlockOperationError::BeaconStateError(e) => BlockOperationError::BeaconStateError(e),
             BlockOperationError::SignatureSetError(e) => BlockOperationError::SignatureSetError(e),
             BlockOperationError::SszTypesError(e) => BlockOperationError::SszTypesError(e),
+            BlockOperationError::SszBitfieldError(e) => BlockOperationError::SszBitfieldError(e),
             BlockOperationError::ConsensusContext(e) => BlockOperationError::ConsensusContext(e),
             BlockOperationError::ArithError(e) => BlockOperationError::ArithError(e),
         }

--- a/consensus/state_processing/src/per_epoch_processing/errors.rs
+++ b/consensus/state_processing/src/per_epoch_processing/errors.rs
@@ -18,10 +18,10 @@ pub enum EpochProcessingError {
     InclusionSlotsInconsistent(usize),
     BeaconStateError(BeaconStateError),
     InclusionError(InclusionError),
-    SszTypesError(ssz_types::Error),
+    SszTypesError(ssz::BitfieldError),
     ArithError(safe_arith::ArithError),
     InconsistentStateFork(InconsistentFork),
-    InvalidJustificationBit(ssz_types::Error),
+    InvalidJustificationBit(ssz::BitfieldError),
     InvalidFlagIndex(usize),
     MilhouseError(milhouse::Error),
     EpochCache(EpochCacheError),
@@ -43,8 +43,8 @@ impl From<BeaconStateError> for EpochProcessingError {
     }
 }
 
-impl From<ssz_types::Error> for EpochProcessingError {
-    fn from(e: ssz_types::Error) -> EpochProcessingError {
+impl From<ssz::BitfieldError> for EpochProcessingError {
+    fn from(e: ssz::BitfieldError) -> EpochProcessingError {
         EpochProcessingError::SszTypesError(e)
     }
 }

--- a/consensus/types/src/attestation.rs
+++ b/consensus/types/src/attestation.rs
@@ -18,17 +18,11 @@ use super::{
 
 #[derive(Debug, PartialEq)]
 pub enum Error {
-    SszTypesError(ssz_types::Error),
+    BitFieldError(ssz::BitfieldError),
     AlreadySigned(usize),
     IncorrectStateVariant,
     InvalidCommitteeLength,
     InvalidCommitteeIndex,
-}
-
-impl From<ssz_types::Error> for Error {
-    fn from(e: ssz_types::Error) -> Self {
-        Error::SszTypesError(e)
-    }
 }
 
 #[superstruct(
@@ -231,7 +225,7 @@ impl<E: EthSpec> Attestation<E> {
         }
     }
 
-    pub fn get_aggregation_bit(&self, index: usize) -> Result<bool, ssz_types::Error> {
+    pub fn get_aggregation_bit(&self, index: usize) -> Result<bool, ssz::BitfieldError> {
         match self {
             Attestation::Base(att) => att.aggregation_bits.get(index),
             Attestation::Electra(att) => att.aggregation_bits.get(index),
@@ -365,13 +359,13 @@ impl<E: EthSpec> AttestationElectra<E> {
         if self
             .aggregation_bits
             .get(committee_position)
-            .map_err(Error::SszTypesError)?
+            .map_err(Error::BitFieldError)?
         {
             Err(Error::AlreadySigned(committee_position))
         } else {
             self.aggregation_bits
                 .set(committee_position, true)
-                .map_err(Error::SszTypesError)?;
+                .map_err(Error::BitFieldError)?;
 
             self.signature.add_assign(signature);
 
@@ -439,13 +433,13 @@ impl<E: EthSpec> AttestationBase<E> {
         if self
             .aggregation_bits
             .get(committee_position)
-            .map_err(Error::SszTypesError)?
+            .map_err(Error::BitFieldError)?
         {
             Err(Error::AlreadySigned(committee_position))
         } else {
             self.aggregation_bits
                 .set(committee_position, true)
-                .map_err(Error::SszTypesError)?;
+                .map_err(Error::BitFieldError)?;
 
             self.signature.add_assign(signature);
 
@@ -455,7 +449,7 @@ impl<E: EthSpec> AttestationBase<E> {
 
     pub fn extend_aggregation_bits(
         &self,
-    ) -> Result<BitList<E::MaxValidatorsPerSlot>, ssz_types::Error> {
+    ) -> Result<BitList<E::MaxValidatorsPerSlot>, ssz::BitfieldError> {
         self.aggregation_bits.resize::<E::MaxValidatorsPerSlot>()
     }
 }

--- a/consensus/types/src/bls_to_execution_change.rs
+++ b/consensus/types/src/bls_to_execution_change.rs
@@ -23,7 +23,6 @@ pub struct BlsToExecutionChange {
     #[serde(with = "serde_utils::quoted_u64")]
     pub validator_index: u64,
     pub from_bls_pubkey: PublicKeyBytes,
-    #[serde(with = "serde_utils::address_hex")]
     pub to_execution_address: Address,
 }
 

--- a/consensus/types/src/chain_spec.rs
+++ b/consensus/types/src/chain_spec.rs
@@ -1449,7 +1449,6 @@ pub struct Config {
     deposit_chain_id: u64,
     #[serde(with = "serde_utils::quoted_u64")]
     deposit_network_id: u64,
-    #[serde(with = "serde_utils::address_hex")]
     deposit_contract_address: Address,
 
     #[serde(default = "default_gas_limit_adjustment_factor")]

--- a/consensus/types/src/execution_block_hash.rs
+++ b/consensus/types/src/execution_block_hash.rs
@@ -21,7 +21,7 @@ use std::fmt;
 )]
 #[derivative(Debug = "transparent")]
 #[serde(transparent)]
-pub struct ExecutionBlockHash(#[serde(with = "serde_utils::b256_hex")] pub Hash256);
+pub struct ExecutionBlockHash(pub Hash256);
 
 impl ExecutionBlockHash {
     pub fn zero() -> Self {

--- a/consensus/types/src/execution_payload.rs
+++ b/consensus/types/src/execution_payload.rs
@@ -51,7 +51,6 @@ pub struct ExecutionPayload<E: EthSpec> {
     #[superstruct(getter(copy))]
     pub parent_hash: ExecutionBlockHash,
     #[superstruct(getter(copy))]
-    #[serde(with = "serde_utils::address_hex")]
     pub fee_recipient: Address,
     #[superstruct(getter(copy))]
     pub state_root: Hash256,

--- a/consensus/types/src/execution_payload_header.rs
+++ b/consensus/types/src/execution_payload_header.rs
@@ -47,7 +47,6 @@ pub struct ExecutionPayloadHeader<E: EthSpec> {
     #[superstruct(getter(copy))]
     pub parent_hash: ExecutionBlockHash,
     #[superstruct(getter(copy))]
-    #[serde(with = "serde_utils::address_hex")]
     pub fee_recipient: Address,
     #[superstruct(getter(copy))]
     pub state_root: Hash256,

--- a/consensus/types/src/proposer_preparation_data.rs
+++ b/consensus/types/src/proposer_preparation_data.rs
@@ -9,6 +9,5 @@ pub struct ProposerPreparationData {
     #[serde(with = "serde_utils::quoted_u64")]
     pub validator_index: u64,
     /// The fee-recipient address.
-    #[serde(with = "serde_utils::address_hex")]
     pub fee_recipient: Address,
 }

--- a/consensus/types/src/sync_aggregate.rs
+++ b/consensus/types/src/sync_aggregate.rs
@@ -10,7 +10,7 @@ use tree_hash_derive::TreeHash;
 
 #[derive(Debug, PartialEq)]
 pub enum Error {
-    SszTypesError(ssz_types::Error),
+    BitfieldError(ssz::BitfieldError),
     ArithError(ArithError),
 }
 
@@ -68,7 +68,7 @@ impl<E: EthSpec> SyncAggregate<E> {
                     sync_aggregate
                         .sync_committee_bits
                         .set(participant_index, true)
-                        .map_err(Error::SszTypesError)?;
+                        .map_err(Error::BitfieldError)?;
                 }
             }
             sync_aggregate

--- a/consensus/types/src/sync_committee_contribution.rs
+++ b/consensus/types/src/sync_committee_contribution.rs
@@ -8,7 +8,7 @@ use tree_hash_derive::TreeHash;
 
 #[derive(Debug, PartialEq)]
 pub enum Error {
-    SszTypesError(ssz_types::Error),
+    BitfieldError(ssz::BitfieldError),
     AlreadySigned(usize),
 }
 
@@ -51,7 +51,7 @@ impl<E: EthSpec> SyncCommitteeContribution<E> {
     ) -> Result<Self, Error> {
         let mut bits = BitVector::new();
         bits.set(validator_sync_committee_index, true)
-            .map_err(Error::SszTypesError)?;
+            .map_err(Error::BitfieldError)?;
         Ok(Self {
             slot: message.slot,
             beacon_block_root: message.beacon_block_root,

--- a/consensus/types/src/validator_registration_data.rs
+++ b/consensus/types/src/validator_registration_data.rs
@@ -12,7 +12,6 @@ pub struct SignedValidatorRegistrationData {
 
 #[derive(PartialEq, Debug, Serialize, Deserialize, Clone, Encode, Decode, TreeHash)]
 pub struct ValidatorRegistrationData {
-    #[serde(with = "serde_utils::address_hex")]
     pub fee_recipient: Address,
     #[serde(with = "serde_utils::quoted_u64")]
     pub gas_limit: u64,

--- a/consensus/types/src/withdrawal.rs
+++ b/consensus/types/src/withdrawal.rs
@@ -24,7 +24,6 @@ pub struct Withdrawal {
     pub index: u64,
     #[serde(with = "serde_utils::quoted_u64")]
     pub validator_index: u64,
-    #[serde(with = "serde_utils::address_hex")]
     pub address: Address,
     #[serde(with = "serde_utils::quoted_u64")]
     pub amount: u64,

--- a/consensus/types/src/withdrawal_request.rs
+++ b/consensus/types/src/withdrawal_request.rs
@@ -21,7 +21,6 @@ use tree_hash_derive::TreeHash;
     TestRandom,
 )]
 pub struct WithdrawalRequest {
-    #[serde(with = "serde_utils::address_hex")]
     pub source_address: Address,
     pub validator_pubkey: PublicKeyBytes,
     #[serde(with = "serde_utils::quoted_u64")]

--- a/crypto/kzg/benches/benchmark.rs
+++ b/crypto/kzg/benches/benchmark.rs
@@ -25,8 +25,13 @@ pub fn bench_init_context(c: &mut Criterion) {
                 serde_json::from_reader(get_trusted_setup().as_slice())
                     .map_err(|e| format!("Unable to read trusted setup file: {}", e))
                     .expect("should have trusted setup");
-            KzgSettings::load_trusted_setup(&trusted_setup.g1_points(), &trusted_setup.g2_points())
-                .unwrap()
+            KzgSettings::load_trusted_setup(
+                &trusted_setup.g1_points(),
+                &trusted_setup.g1_monomial_points(),
+                &trusted_setup.g2_points(),
+                0,
+            )
+            .unwrap()
         })
     });
 }

--- a/crypto/kzg/src/lib.rs
+++ b/crypto/kzg/src/lib.rs
@@ -66,7 +66,9 @@ impl Kzg {
         Ok(Self {
             trusted_setup: KzgSettings::load_trusted_setup(
                 &trusted_setup.g1_points(),
+                &trusted_setup.g1_monomial_points(),
                 &trusted_setup.g2_points(),
+                0,
             )?,
             context,
         })
@@ -86,7 +88,9 @@ impl Kzg {
         Ok(Self {
             trusted_setup: KzgSettings::load_trusted_setup(
                 &trusted_setup.g1_points(),
+                &trusted_setup.g1_monomial_points(),
                 &trusted_setup.g2_points(),
+                0,
             )?,
             context,
         })
@@ -112,7 +116,9 @@ impl Kzg {
         Ok(Self {
             trusted_setup: KzgSettings::load_trusted_setup(
                 &trusted_setup.g1_points(),
+                &trusted_setup.g1_monomial_points(),
                 &trusted_setup.g2_points(),
+                0,
             )?,
             context,
         })
@@ -128,7 +134,8 @@ impl Kzg {
         blob: &Blob,
         kzg_commitment: KzgCommitment,
     ) -> Result<KzgProof, Error> {
-        c_kzg::KzgProof::compute_blob_kzg_proof(blob, &kzg_commitment.into(), &self.trusted_setup)
+        self.trusted_setup
+            .compute_blob_kzg_proof(blob, &kzg_commitment.into())
             .map(|proof| KzgProof(proof.to_bytes().into_inner()))
             .map_err(Into::into)
     }
@@ -140,11 +147,10 @@ impl Kzg {
         kzg_commitment: KzgCommitment,
         kzg_proof: KzgProof,
     ) -> Result<(), Error> {
-        if !c_kzg::KzgProof::verify_blob_kzg_proof(
+        if self.trusted_setup.verify_blob_kzg_proof(
             blob,
             &kzg_commitment.into(),
             &kzg_proof.into(),
-            &self.trusted_setup,
         )? {
             Err(Error::KzgVerificationFailed)
         } else {
@@ -172,11 +178,10 @@ impl Kzg {
             .map(|proof| Bytes48::from(*proof))
             .collect::<Vec<_>>();
 
-        if !c_kzg::KzgProof::verify_blob_kzg_proof_batch(
+        if !self.trusted_setup.verify_blob_kzg_proof_batch(
             blobs,
             &commitments_bytes,
             &proofs_bytes,
-            &self.trusted_setup,
         )? {
             Err(Error::KzgVerificationFailed)
         } else {
@@ -186,7 +191,8 @@ impl Kzg {
 
     /// Converts a blob to a kzg commitment.
     pub fn blob_to_kzg_commitment(&self, blob: &Blob) -> Result<KzgCommitment, Error> {
-        c_kzg::KzgCommitment::blob_to_kzg_commitment(blob, &self.trusted_setup)
+        self.trusted_setup
+            .blob_to_kzg_commitment(blob)
             .map(|commitment| KzgCommitment(commitment.to_bytes().into_inner()))
             .map_err(Into::into)
     }
@@ -197,7 +203,8 @@ impl Kzg {
         blob: &Blob,
         z: &Bytes32,
     ) -> Result<(KzgProof, Bytes32), Error> {
-        c_kzg::KzgProof::compute_kzg_proof(blob, z, &self.trusted_setup)
+        self.trusted_setup
+            .compute_kzg_proof(blob, z)
             .map(|(proof, y)| (KzgProof(proof.to_bytes().into_inner()), y))
             .map_err(Into::into)
     }
@@ -210,14 +217,9 @@ impl Kzg {
         y: &Bytes32,
         kzg_proof: KzgProof,
     ) -> Result<bool, Error> {
-        c_kzg::KzgProof::verify_kzg_proof(
-            &kzg_commitment.into(),
-            z,
-            y,
-            &kzg_proof.into(),
-            &self.trusted_setup,
-        )
-        .map_err(Into::into)
+        self.trusted_setup
+            .verify_kzg_proof(&kzg_commitment.into(), z, y, &kzg_proof.into())
+            .map_err(Into::into)
     }
 
     /// Computes the cells and associated proofs for a given `blob` at index `index`.

--- a/crypto/kzg/src/trusted_setup.rs
+++ b/crypto/kzg/src/trusted_setup.rs
@@ -1,5 +1,4 @@
 use crate::PeerDASTrustedSetup;
-use c_kzg::{BYTES_PER_G1_POINT, BYTES_PER_G2_POINT};
 use serde::{
     de::{self, Deserializer, Visitor},
     Deserialize, Serialize,
@@ -10,6 +9,9 @@ pub const TRUSTED_SETUP_BYTES: &[u8] = include_bytes!("../trusted_setup.json");
 pub fn get_trusted_setup() -> Vec<u8> {
     TRUSTED_SETUP_BYTES.into()
 }
+
+pub const BYTES_PER_G1_POINT: usize = 48;
+pub const BYTES_PER_G2_POINT: usize = 96;
 
 /// Wrapper over a BLS G1 point's byte representation.
 #[derive(Debug, Clone, PartialEq)]
@@ -37,12 +39,28 @@ pub struct TrustedSetup {
 }
 
 impl TrustedSetup {
-    pub fn g1_points(&self) -> Vec<[u8; BYTES_PER_G1_POINT]> {
-        self.g1_points.iter().map(|p| p.0).collect()
+    pub fn g1_points(&self) -> Vec<u8> {
+        self.g1_points
+            .iter()
+            .map(|p| p.0.as_slice())
+            .collect::<Vec<_>>()
+            .concat()
     }
 
-    pub fn g2_points(&self) -> Vec<[u8; BYTES_PER_G2_POINT]> {
-        self.g2_points.iter().map(|p| p.0).collect()
+    pub fn g1_monomial_points(&self) -> Vec<u8> {
+        self.g1_monomial_points
+            .iter()
+            .map(|p| p.0.as_slice())
+            .collect::<Vec<_>>()
+            .concat()
+    }
+
+    pub fn g2_points(&self) -> Vec<u8> {
+        self.g2_points
+            .iter()
+            .map(|p| p.0.as_slice())
+            .collect::<Vec<_>>()
+            .concat()
     }
 
     pub fn g1_len(&self) -> usize {


### PR DESCRIPTION
c-kzg v2 is used by alloy and reth, but it's incompatible with v1 used by lighthouse.

This also required bumping a lot of unrelated dependencies because they all import each other. Fun!